### PR TITLE
Fix getLikes

### DIFF
--- a/src/video/video.ts
+++ b/src/video/video.ts
@@ -86,5 +86,5 @@ function getLikes(videoPrimaryInfoRenderer){
 		likeButton = likeButton.segmentedLikeDislikeButtonRenderer.likeButton;
 	}
 
-	return parseNumber(likeButton.toggleButtonRenderer.defaultText) || 0;
+	return parseNumber(likeButton?.segmentedLikeDislikeButtonViewModel?.likeButtonViewModel?.likeButtonViewModel?.toggleButtonViewModel?.toggleButtonViewModel?.defaultButtonViewModel?.buttonViewModel?.title) || 0;
 }


### PR DESCRIPTION
Fixes the following error:
TypeError: Cannot read properties of undefined (reading 'defaultText') 
at getLikes (/node_modules/@fabricio-191/youtube/lib/methods/video.js:111:58)


Added the "?." operator in case the path changes in the future. Will default to 'undefined' or 'null' if it does.